### PR TITLE
feat(@gat/node_server): switching libraries form node-wifi to wireles…

### DIFF
--- a/packages/node_server/dist/install.js
+++ b/packages/node_server/dist/install.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const child = require("child_process");
-child.execSync('npm install');
-child.execSync('node ./dist/node_server.js');
+console.log(child.execSync('npm install'));
+console.log(child.execSync('node ./dist/node_server.js'));
 console.log("YOU DID IT MAX!");

--- a/packages/node_server/dist/node_server.d.ts
+++ b/packages/node_server/dist/node_server.d.ts
@@ -1,1 +1,5 @@
-declare var wifi: any;
+export declare class node_server {
+    run(): Promise<Error>;
+    private __createAccessPoint;
+    private __scanWireless;
+}

--- a/packages/node_server/dist/node_server.js
+++ b/packages/node_server/dist/node_server.js
@@ -1,39 +1,70 @@
-var wifi = require('node-wifi');
-wifi.init({
-    iface: null
-});
-wifi.scan(function (err, networks) {
-    if (err) {
-        console.log(err);
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+let wifi = require('node-wifi');
+let wirelessToolsHostApd = require('wireless-tools/hostapd');
+class node_server {
+    run() {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                yield this.__createAccessPoint();
+                yield this.__scanWireless();
+            }
+            catch (e) {
+                return Error('No Bueno when running. Error said: ' + e);
+            }
+        });
     }
-    else {
-        console.log(networks);
+    __createAccessPoint() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const hostapdOptions = {
+                channel: 6,
+                driver: 'rtl871xdrv',
+                hw_mode: 'g',
+                interface: 'wlan0',
+                ssid: 'RaspberryPi',
+                wpa: 2,
+                wpa_passphrase: 'raspberry'
+            };
+            return yield new Promise((resolve, reject) => {
+                wirelessToolsHostApd.enable(hostapdOptions, (err) => {
+                    if (!err) {
+                        reject(err);
+                        return err;
+                    }
+                    resolve();
+                });
+            });
+        });
     }
-});
-wifi.connect({ ssid: "ssid", password: "password" }, function (err) {
-    if (err) {
-        console.log(err);
+    __scanWireless() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield new Promise((resolve, reject) => {
+                wifi.init({
+                    iface: null
+                });
+                wifi.scan(function (err, networks) {
+                    if (err) {
+                        console.log(err);
+                        reject(err);
+                        return err;
+                    }
+                    else {
+                        console.log(networks);
+                        resolve(networks);
+                    }
+                });
+            });
+        });
     }
-    console.log('Connected');
-});
-wifi.disconnect(function (err) {
-    if (err) {
-        console.log(err);
-    }
-    console.log('Disconnected');
-});
-wifi.deleteConnection({ ssid: "ssid" }, function (err) {
-    if (err) {
-        console.log(err);
-    }
-    console.log('Deleted');
-});
-wifi.getCurrentConnections(function (err, currentConnections) {
-    if (err) {
-        console.log(err);
-    }
-    console.log(currentConnections);
-});
-wifi.scan().then(function (networks) {
-}).catch(function (error) {
-});
+}
+exports.node_server = node_server;
+let instanceOfNodeServer = new node_server();
+instanceOfNodeServer.run();

--- a/packages/node_server/dist/wlan0-hostapd.conf
+++ b/packages/node_server/dist/wlan0-hostapd.conf
@@ -1,0 +1,7 @@
+channel=6
+driver=rtl871xdrv
+hw_mode=g
+interface=wlan0
+ssid=RaspberryPi
+wpa=2
+wpa_passphrase=raspberry

--- a/packages/node_server/installs/install.sh
+++ b/packages/node_server/installs/install.sh
@@ -1,12 +1,17 @@
-echo 'export PATH=$HOME/local/bin:$PATH' >> ~/.bashrc
-. ~/.bashrc
-mkdir ~/local
-mkdir ~/node-latest-install
-cd ~/node-latest-install
-curl http://nodejs.org/dist/node-latest.tar.gz | tar xz --strip-components=1
-./configure --prefix=~/local
-make install # ok, fine, this step probably takes more than 30 seconds...
-curl https://www.npmjs.org/install.sh | sh
+mkdir ~/local &
+mkdir ~/local/nodeArm6Install &
+cd ~/local/nodeArm6Install &
+
+# wpa_cli -i wlan0 reconfigure if your wifi does not show inet for wlan0
+wget https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-armv6l.tar.xz &
+
+tar -xfnode-v10.15.3-linux-armv6l.tar.xz &
+
+cd node-v10.15.3-linux-armv6l/ &
+sudo cp -R * /usr/local/ &
+
+node -v &
+npm -v &
 
 mkdir ~/local/gat
 cd ~/local/gat

--- a/packages/node_server/package-lock.json
+++ b/packages/node_server/package-lock.json
@@ -153,6 +153,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
       "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
     },
+    "wireless-tools": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/wireless-tools/-/wireless-tools-0.19.0.tgz",
+      "integrity": "sha1-Z/tzzTcfLZujue8lNACjH4x4SxE="
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/packages/node_server/package.json
+++ b/packages/node_server/package.json
@@ -33,7 +33,8 @@
     "url": "https://github.com/GameAnywhereTechnology/gat/issues"
   },
   "dependencies": {
-    "typescript": "^3.4.5"
+    "typescript": "^3.4.5",
+    "wireless-tools": "^0.19.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.3",

--- a/packages/node_server/src/install.ts
+++ b/packages/node_server/src/install.ts
@@ -2,6 +2,6 @@
 
 import * as child from 'child_process';
 
-child.execSync('npm install');
-child.execSync('node ./dist/node_server.js');
+console.log(child.execSync('npm install'));
+console.log(child.execSync('node ./dist/node_server.js'));
 console.log("YOU DID IT MAX!");

--- a/packages/node_server/src/node_server.ts
+++ b/packages/node_server/src/node_server.ts
@@ -1,93 +1,160 @@
 
-var wifi = require('node-wifi');
- 
-// Initialize wifi module
-// Absolutely necessary even to set interface to null
-wifi.init({
-    iface : null // network interface, choose a random wifi interface if set to null
-});
- 
-// Scan networks
-wifi.scan(function(err, networks) {
-    if (err) {
-        console.log(err);
-    } else {
-        console.log(networks);
-        /*
-        networks = [
-            {
-              ssid: '...',
-              bssid: '...',
-              mac: '...', // equals to bssid (for retrocompatibility)
-              channel: <number>,
-              frequency: <number>, // in MHz
-              signal_level: <number>, // in dB
-              quality: <number>, // same as signal level but in %
-              security: 'WPA WPA2' // format depending on locale for open networks in Windows
-              security_flags: '...' // encryption protocols (format currently depending of the OS)
-              mode: '...' // network mode like Infra (format currently depending of the OS)
-            },
-            ...
-        ];
-        */
-    }
-});
- 
-// Connect to a network
-wifi.connect({ ssid : "ssid", password : "password"}, function(err) {
-    if (err) {
-        console.log(err);
-    }
-    console.log('Connected');
-});
- 
-// Disconnect from a network
-// not available on all os for now
-wifi.disconnect(function(err) {
-    if (err) {
-        console.log(err);
-    }
-    console.log('Disconnected');
-});
- 
-// Delete a saved network
-// not available on all os for now
-wifi.deleteConnection({ ssid : "ssid"}, function(err) {
-    if (err) {
-        console.log(err);
-    }
-    console.log('Deleted');
-});
- 
-// List the current wifi connections
-wifi.getCurrentConnections(function(err, currentConnections) {
-    if (err) {
-        console.log(err);
-    }
-    console.log(currentConnections);
-    /*
-    // you may have several connections
-    [
-        {
-            iface: '...', // network interface used for the connection, not available on macOS
-            ssid: '...',
-            bssid: '...',
-            mac: '...', // equals to bssid (for retrocompatibility)
-            channel: <number>,
-            frequency: <number>, // in MHz
-            signal_level: <number>, // in dB
-            quality: <number>, // same as signal level but in %
-            security: '...' //
-            security_flags: '...' // encryption protocols (format currently depending of the OS)
-            mode: '...' // network mode like Infra (format currently depending of the OS)
+let wifi = require('node-wifi');
+let wirelessToolsHostApd = require('wireless-tools/hostapd');
+
+export class node_server {
+    public async run () {
+        try {
+            await this.__createAccessPoint();
+            await this.__scanWireless();
+        } catch (e) {
+            return Error('No Bueno when running. Error said: ' + e);
         }
-    ]
-    */
-});
- 
-// All functions also return promise if there is no callback given
-wifi.scan().then(function (networks) {
-  // networks
-}).catch(function (error) {
-  // error
-})
+    }
+
+    private async __createAccessPoint () : Promise<any> {
+        const hostapdOptions = {
+            channel: 6,
+            driver: 'rtl871xdrv',
+            hw_mode: 'g',
+            interface: 'wlan0',
+            ssid: 'RaspberryPi',
+            wpa: 2,
+            wpa_passphrase: 'raspberry'
+        };
+
+        return await new Promise<any>((resolve, reject) => {
+            wirelessToolsHostApd.enable(hostapdOptions, (err) => {
+                // the access point was created
+                if (!err) {
+                    reject(err);
+                    return err;
+                }
+
+                resolve();
+            });
+        });
+    }
+
+    private async __scanWireless () {
+        return await new Promise<any>((resolve, reject) => {
+            // Initialize wifi module
+            // Absolutely necessary even to set interface to null
+            wifi.init({
+                iface : null // network interface, choose a random wifi interface if set to null
+            });
+            
+            // Scan networks
+            wifi.scan(function(err, networks) {
+                if (err) {
+                    console.log(err);
+                    reject(err);
+                    return err;
+                } else {
+                    console.log(networks);
+                    /*
+                    networks = [
+                        {
+                        ssid: '...',
+                        bssid: '...',
+                        mac: '...', // equals to bssid (for retrocompatibility)
+                        channel: <number>,
+                        frequency: <number>, // in MHz
+                        signal_level: <number>, // in dB
+                        quality: <number>, // same as signal level but in %
+                        security: 'WPA WPA2' // format depending on locale for open networks in Windows
+                        security_flags: '...' // encryption protocols (format currently depending of the OS)
+                        mode: '...' // network mode like Infra (format currently depending of the OS)
+                        },
+                        ...
+                    ];
+                    */
+                   resolve(networks);
+                }
+            });
+        });
+    }
+}
+
+
+
+
+
+// const hostapdOptions = {
+//     channel: 6,
+//     driver: 'rtl871xdrv',
+//     hw_mode: 'g',
+//     interface: 'wlan0',
+//     ssid: 'RaspberryPi',
+//     wpa: 2,
+//     wpa_passphrase: 'raspberry'
+// };
+
+// wirelessToolsHostApd.enable(hostapdOptions, (err) => {
+//     // the access point was created
+//     if (!err) {
+
+//     }
+// });
+
+// // Connect to a network
+// wifi.connect({ ssid : "ssid", password : "password"}, function(err) {
+//     if (err) {
+//         console.log(err);
+//     }
+//     console.log('Connected');
+// });
+
+// // Disconnect from a network
+// // not available on all os for now
+// wifi.disconnect(function(err) {
+//     if (err) {
+//         console.log(err);
+//     }
+//     console.log('Disconnected');
+// });
+
+// // Delete a saved network
+// // not available on all os for now
+// wifi.deleteConnection({ ssid : "ssid"}, function(err) {
+//     if (err) {
+//         console.log(err);
+//     }
+//     console.log('Deleted');
+// });
+
+// // List the current wifi connections
+// wifi.getCurrentConnections(function(err, currentConnections) {
+//     if (err) {
+//         console.log(err);
+//     }
+//     console.log(currentConnections);
+//     /*
+//     // you may have several connections
+//     [
+//         {
+//             iface: '...', // network interface used for the connection, not available on macOS
+//             ssid: '...',
+//             bssid: '...',
+//             mac: '...', // equals to bssid (for retrocompatibility)
+//             channel: <number>,
+//             frequency: <number>, // in MHz
+//             signal_level: <number>, // in dB
+//             quality: <number>, // same as signal level but in %
+//             security: '...' //
+//             security_flags: '...' // encryption protocols (format currently depending of the OS)
+//             mode: '...' // network mode like Infra (format currently depending of the OS)
+//         }
+//     ]
+//     */
+// });
+
+// // All functions also return promise if there is no callback given
+// wifi.scan().then(function (networks) {
+// // networks
+// }).catch(function (error) {
+// // error
+// })
+
+let instanceOfNodeServer = new node_server();
+instanceOfNodeServer.run();

--- a/packages/node_server/wlan0-hostapd.conf
+++ b/packages/node_server/wlan0-hostapd.conf
@@ -1,0 +1,7 @@
+channel=6
+driver=rtl871xdrv
+hw_mode=g
+interface=wlan0
+ssid=RaspberryPi
+wpa=2
+wpa_passphrase=raspberry


### PR DESCRIPTION
…s-tools for hostapd integration

affects: @gat/node_server

Node-wifi only scanned, and wireless tools allows us to create an access point programmatically.

ISSUES CLOSED: #5